### PR TITLE
Removal of aws-iam-authenticator binary download and references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.zip
 event.json
 kubectl
-aws-iam-authenticator
 lambda.output
 layer
 sam-layer-packaged.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
 
 
 
-# download kubectl and aws-iam-authenticator
+# download kubectl
 ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/kubectl /opt/kubectl/
-ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator  /opt/kubectl/
-RUN chmod +x /opt/kubectl/kubectl /opt/kubectl/aws-iam-authenticator
+RUN chmod +x /opt/kubectl/kubectl
   
 #
 # prepare the runtime at /opt/kubectl
@@ -46,10 +45,9 @@ COPY --from=builder /opt/awscli/jq /opt/awscli/jq;
 COPY --from=builder /usr/bin/make /opt/awscli/make; 
 
 #
-# kubectl and aws-iam-authenticator
+# kubectl
 #
 COPY --from=builder /opt/kubectl/kubectl /opt/kubectl/kubectl
-COPY --from=builder /opt/kubectl/aws-iam-authenticator /opt/kubectl/aws-iam-authenticator
 
 # remove unnecessary files to reduce the size
 RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Features
 
-- [x] Ships all the required assests including `kubectl`, `aws-iam-authenticator`, `aws` CLI and `jq`. Just include the layer and you get everything required.
+- [x] Ships all the required assests including `kubectl`, `aws` CLI and `jq`. Just include the layer and you get everything required.
 - [x] It takes care of the Amazon EKS authentication behind the scene.
 - [x] Straight `kubectl` against Amazon EKS without `client-go` or python client SDK for K8s. Zero code experience required. Just shell script.
 - [x] Invoke your Lambda function with any `yaml` file from local and it can `kubectl apply -f` for you to apply it on Amazon EKS.
@@ -60,7 +60,6 @@ You got the layer structure as below under `/opt` in lambda custom runtime:
 │   ├── wheel-0.29.0.dist-info
 │   └── yaml
 └── kubectl
-    ├── aws-iam-authenticator
     └── kubectl
 
 31 directories, 9 files


### PR DESCRIPTION
*Issue #, if available:*

aws-iam-authenticator binary is no longer needed

*Description of changes:*

Removal of binary download and references.

*Testing*

Update layer run with successful `kubectl version`, server version is returned indicating authentication functioning with the `aws eks get-token` CLI command.

```
=========[RESPONSE]=======
cluster_name=<omitted>
Client Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.5", GitCommit:"753b2dbc622f5cc417845f0ff8a77f539a4213ea", GitTreeState:"clean", BuildDate:"2018-12-06T01:33:57Z", GoVersion:"go1.10.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"12+", GitVersion:"v1.12.6-eks-d69f1b", GitCommit:"d69f1bf3669bf00b7f4a758e978e0e7a1e3a68f7", GitTreeState:"clean", BuildDate:"2019-02-28T20:26:10Z", GoVersion:"go1.10.8", Compiler:"gc", Platform:"linux/amd64"}
=========[/RESPONSE]=======
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
