### PR TITLE
Add Helm 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM amazonlinux:latest as builder
 
 WORKDIR /root
 
-RUN yum update -y && yum install -y unzip make wget
+RUN yum update -y && yum install -y unzip make wget tar gzip
 
 ADD https://s3.amazonaws.com/aws-cli/awscli-bundle.zip /root
 
@@ -21,6 +21,9 @@ RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
 # download kubectl
 ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl /opt/kubectl/
 RUN chmod +x /opt/kubectl/kubectl
+
+# download helm v3
+RUN mkdir -p /opt/helm && wget -qO- https://get.helm.sh/helm-v3.0.0-linux-amd64.tar.gz | tar -xz -C /opt/helm/
   
 #
 # prepare the runtime at /opt/kubectl
@@ -46,6 +49,12 @@ COPY --from=builder /usr/bin/make /opt/awscli/make;
 # kubectl
 #
 COPY --from=builder /opt/kubectl/kubectl /opt/kubectl/kubectl
+
+#
+# helm
+#
+COPY --from=builder /opt/helm/linux-amd64/helm /opt/helm/helm
+
 
 # remove unnecessary files to reduce the size
 RUN rm -rf /opt/awscli/pip* /opt/awscli/setuptools* /opt/awscli/awscli/examples

--- a/bootstrap
+++ b/bootstrap
@@ -5,7 +5,7 @@ set -euo pipefail
 # Initialization - load function handler
 #source $LAMBDA_TASK_ROOT/"$(echo $_HANDLER | cut -d. -f1).sh"
 
-export PATH=$PATH:/opt/awscli:/opt/kubectl
+export PATH=$PATH:/opt/awscli:/opt/kubectl:/opt/helm
 
 if [ -z ${cluster_name:-} ]; then
     echo "missing cluster_name in lambda environment variables - using 'default' as the cluster_name"

--- a/libs.sh
+++ b/libs.sh
@@ -1,5 +1,11 @@
 export KUBECONFIG=/tmp/kubeconfig
 
+HELM_HOME=/tmp/helm
+mkdir -p $HELM_HOME
+export XDG_CACHE_HOME=$HELM_HOME/.cache
+export XDG_CONFIG_HOME=$HELM_HOME/.config
+export XDG_DATA_HOME=$HELM_HOME/.data
+
 update_kubeconfig(){
     aws eks update-kubeconfig --name "$1"  --kubeconfig /tmp/kubeconfig
 }


### PR DESCRIPTION
*Issue #, if available:*
#6 

*Description of changes:*
Add Helm client v3 to support helm charts installation in lambda.

Since [Helm 3 has removed Tiller](https://github.com/helm/helm/releases/tag/v3.0.0), then Helm client can be worked without any other configuration/installation in Kubernetes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
