### PR TITLE
Adding http_proxy build args support for docker build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,6 @@
 
 TAG='aws-lambda-layer-kubectl'
 
-docker build --build-arg HTTP_PROXYX --build-arg HTTPS_PROXY --build-arg http_proxy --build-arg https_proxy --no-cache -t $TAG .
+docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg http_proxy --build-arg https_proxy --no-cache -t $TAG .
 CONTAINER=$(docker run -d $TAG false)
 docker cp ${CONTAINER}:/layer.zip layer.zip

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,6 @@
 
 TAG='aws-lambda-layer-kubectl'
 
-docker build --no-cache -t $TAG .
+docker build --build-arg HTTP_PROXYX --build-arg HTTPS_PROXY --build-arg http_proxy --build-arg https_proxy --no-cache -t $TAG .
 CONTAINER=$(docker run -d $TAG false)
 docker cp ${CONTAINER}:/layer.zip layer.zip


### PR DESCRIPTION
*Description of changes:*

Adding http_build vars to docker build command. Variables are pulled from shell environment. If they are set, build works with proxy. If they are not set, everything works as before. Tested both.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
